### PR TITLE
Corrected mistake on query parameter sign

### DIFF
--- a/parampp.py
+++ b/parampp.py
@@ -494,7 +494,7 @@ if __name__ == '__main__':
     print ('{}I\'ve found {} new real parametrs in follow request{}'.format(OKGREEN,len(finish),ENDC))
     link = args.url
     for param in finish:
-        link+='&'+param+'='+str(args.default)
+        link+='?'+param+'='+str(args.default)
 
     print (OKGREEN + link + ENDC)
 


### PR DESCRIPTION
Query parameter sign is ? not &, so corrected it.